### PR TITLE
major rework of addon

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,8 @@ module.exports = {
         'testem.js',
         'blueprints/*/index.js',
         'config/**/*.js',
-        'tests/dummy/config/**/*.js'
+        'lib/**/*.js',
+        'tests/dummy/config/**/*.js',
       ],
       excludedFiles: [
         'addon/**',

--- a/README.md
+++ b/README.md
@@ -9,12 +9,51 @@ template locations as files with `.md` or `.markdown` extension. These templates
 to the regular '.hbs' format at the build time. Actually, you can even use HTMLBars helpers in your
 Markdown templates.
 
-To convert Markdown templates, this addon uses the [Showdown](https://github.com/showdownjs/showdown)
+To convert Markdown templates, this addon uses the [Marked](https://github.com/markedjs/marked)
 library.
 
 ## Installation
 
 * `ember install ember-cli-markdown-templates`
+
+## Options
+
+You can configure ember-cli-markdown-templates by specifying some options on your `ember-cli-build.js`
+file. Example:
+
+```js
+'ember-cli-markdown-templates': {
+  wrapper: '<div class="markdown">{{html}}</div>',
+  syntaxHighlight: true,
+  linkifyHeadings: true,
+  markedOptions: {
+    headerPrefix: 'header-'
+  }
+}
+```
+
+Options:
+
+- `wrapper` - defaults to `false` - use this option to specify some wrapper html around the result of the markdown parsing. ember-cli-markdown-templates
+will replace the string `{{html}}` with the html result of marked. This is sometimes useful to target styles to generated html.
+- `syntaxHighlight` - defaults to `false` - if you set this to `true` ember-cli-markdown-templates will use HighlightJS to generate the code blocks.
+- `linkifyHeadings` - defaults to `false` - ember-cli-markdown-templates can wrap headings text in an anchor tag with the same id as the `<hX>` tag itself.
+This can be useful for navigation. Specify `true` to linkify all heading levels, or a number to only linkify **after** that level. e.g `linkifyHeadings: 3` will only linkify header `<h3>` levels and above.
+- `markedOptions` - defaults to `{}` - you can customize the underlying marked parser by passing [any supported marked options](https://marked.js.org/#/USING_ADVANCED.md#options) in this hash.
+
+## Syntax Higlighting Styles
+
+ember-cli-markdown-templates *does not include* any highlight.js styles, even if you specify `syntaxHighlight: true`.
+You can include them yourself in any way, either making your own theme in your app styles or importing one of the bundled themes in your
+`ember-cli-build.js`. E.g:
+
+```js
+app.import('node_modules/highlightjs/styles/default.css');
+```
+
+Keep in mind that your final app will not have any highlight.js javascript included. All of the syntax highlighting
+is done on node at build time and then converted to a normal hbs template. This is great because it won't
+impact the build size and loading times of your app.
 
 ## Ember-CLI support
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,6 +5,14 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
     // Add options here
+    'ember-cli-markdown-templates': {
+      wrapper: '<div class="markdown">{{html}}</div>',
+      syntaxHighlight: true,
+      linkifyHeadings: true,
+      markedOptions: {
+        headerPrefix: 'header-'
+      }
+    }
   });
 
   /*
@@ -13,6 +21,8 @@ module.exports = function(defaults) {
     This build file does *not* influence how the addon or the app using it
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
+
+  app.import('node_modules/highlightjs/styles/default.css');
 
   return app.toTree();
 };

--- a/index.js
+++ b/index.js
@@ -1,39 +1,31 @@
 'use strict';
 
-var Filter = require('broccoli-filter');
-var Showdown = require('showdown');
-var converter = new Showdown.Converter();
-
-function MarkdownCompiler (inputTree, options) {
-  if (!(this instanceof MarkdownCompiler)) {
-    return new MarkdownCompiler(inputTree, options);
-  }
-
-  Filter.call(this, inputTree, options);
-}
-
-
-MarkdownCompiler.prototype = Object.create(Filter.prototype);
-MarkdownCompiler.prototype.constructor = MarkdownCompiler;
-MarkdownCompiler.prototype.extensions = ['md', 'markdown'];
-MarkdownCompiler.prototype.targetExtension = 'hbs';
-
-MarkdownCompiler.prototype.processString = function (string, relativePath) {
-  return converter.makeHtml(string);
-}
-
-
 module.exports = {
   name: 'ember-cli-markdown-templates',
 
-  setupPreprocessorRegistry: function(type, registry) {
-    var compiler = {
-      name: 'ember-cli-markdown-templates',
-      ext: ['md', 'markdown'],
-      toTree: function(tree) {
-        return MarkdownCompiler(tree, {});
+  /**
+   * Default configuration for this addon.
+   * Augments the applications configuration settings.
+   * Object returned from this hook is merged with the application's configuration object.
+   * Application's configuration always take precedence.
+   */
+  config() {
+    return {
+      'ember-cli-markdown-templates': {
+        targetHandlebars: true,
+        wrapper: false,
+        linkifyHeadings: false,
+        syntaxHighlight: false,
+        markedOptions: {}
       }
     };
-    registry.add('template', compiler);
+  },
+
+  setupPreprocessorRegistry(type, registry) {
+    if (type === 'parent') {
+      let options = this.app.options['ember-cli-markdown-templates'];
+      let TemplateCompiler = require('./lib/markdown-template-compiler');
+      registry.add('template', new TemplateCompiler(options));
+    }
   }
 };

--- a/index.js
+++ b/index.js
@@ -3,24 +3,6 @@
 module.exports = {
   name: 'ember-cli-markdown-templates',
 
-  /**
-   * Default configuration for this addon.
-   * Augments the applications configuration settings.
-   * Object returned from this hook is merged with the application's configuration object.
-   * Application's configuration always take precedence.
-   */
-  config() {
-    return {
-      'ember-cli-markdown-templates': {
-        targetHandlebars: true,
-        wrapper: false,
-        linkifyHeadings: false,
-        syntaxHighlight: false,
-        markedOptions: {}
-      }
-    };
-  },
-
   setupPreprocessorRegistry(type, registry) {
     if (type === 'parent') {
       let options = this.app.options['ember-cli-markdown-templates'];

--- a/lib/compile-markdown.js
+++ b/lib/compile-markdown.js
@@ -1,0 +1,136 @@
+'use strict';
+
+const marked = require('marked');
+const highlightjs = require('highlightjs');
+
+module.exports = function compileMarkdown(source, config) {
+  let tokens = marked.lexer(source);
+
+  // we need to use marked.defaults to preserve marked default options
+  let markedOptions = Object.assign(marked.defaults, config.markedOptions);
+
+  markedOptions.renderer = new HBSRenderer(config);
+
+  if (config.syntaxHighlight) {
+    markedOptions.highlight = highlight;
+  }
+
+  if (config && config.targetHandlebars) {
+    tokens = compactParagraphs(tokens);
+  }
+
+  let html = marked.parser(tokens, markedOptions).trim();
+
+  if (config.wrapper) {
+    if (typeof config.wrapper !== 'string' || config.wrapper.indexOf('{{html}}') === -1) {
+      throw new Error('ember-cli-markdown-templates the passed in `wrapper` config is either not a string or does not have a {{html}} substring');
+    }
+    html = config.wrapper.replace('{{html}}', html);
+  }
+
+  return html;
+};
+
+function highlight(code, lang) {
+  if (lang) {
+    return highlightjs.highlight(lang, code).value;
+  } else {
+    return highlightjs.highlightAuto(code).value;
+  }
+}
+
+// Whitespace can imply paragraphs in Markdown, which can result
+// in interleaving between <p> tags and block component invocations,
+// so this scans the Marked tokens to turn things like this:
+//    <p>{{#my-component}}<p>
+//    <p>{{/my-component}}</p>
+// Into this:
+//    <p>{{#my-component}} {{/my-component}}</p>
+function compactParagraphs(tokens) {
+  let compacted = [];
+
+  compacted.links = tokens.links;
+
+  let balance = 0;
+  for (let token of tokens) {
+    if (balance === 0) {
+      compacted.push(token);
+    } else if (token.text) {
+      let last = compacted[compacted.length - 1];
+      last.text = `${last.text} ${token.text}`;
+    }
+
+    balance += count(/\{\{#/g, token.text);
+    balance -= count(/\{\{\//g, token.text);
+  }
+
+  return compacted;
+}
+
+function count(regex, string) {
+  let total = 0;
+  while (regex.exec(string)) total++;
+  return total;
+}
+
+class HBSRenderer extends marked.Renderer {
+  constructor(config) {
+    super();
+    this.config = config || {};
+  }
+
+  codespan() {
+    return this._processCode(super.codespan.apply(this, arguments));
+  }
+
+  code() {
+    return this._processCode(super.code.apply(this, arguments));
+  }
+
+  // Unescape markdown escaping in general, since it can interfere with
+  // Handlebars templating
+  text() {
+    let text = super.text.apply(this, arguments);
+    if (this.config.targetHandlebars) {
+      text = text
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;|&#34;/g, '"')
+        .replace(/&apos;|&#39;/g, '\'');
+    }
+    return text;
+  }
+
+  // Escape curlies in code spans/blocks to avoid treating them as Handlebars
+  _processCode(string) {
+    if (this.config.targetHandlebars) {
+      string = this._escapeCurlies(string);
+    }
+
+    return string;
+  }
+
+  _escapeCurlies(string) {
+    return string
+      .replace(/{{/g, '&#123;&#123;')
+      .replace(/}}/g, '&#125;&#125;');
+  }
+
+  heading(text, level) {
+    let linkifyHeadings = this.config.linkifyHeadings;
+
+    if (linkifyHeadings) {
+      let sinceLevel = typeof linkifyHeadings === 'boolean' ? 1 : this.config.linkifyHeadings;
+
+      let id = this.options.headerPrefix + text.toLowerCase().replace(/<\/?.*?>/g, '').replace(/[^\w]+/g, '-');
+      let inner = level < sinceLevel ? text : `<a href="#${id}">${text}</a>`;
+
+      return `
+        <h${level} id="${id}">${inner}</h${level}>
+      `;
+    } else {
+      return super.heading.apply(this, arguments);
+    }
+  }
+}

--- a/lib/compile-markdown.js
+++ b/lib/compile-markdown.js
@@ -3,11 +3,20 @@
 const marked = require('marked');
 const highlightjs = require('highlightjs');
 
+const DEFAULTS = {
+  targetHandlebars: true,
+  wrapper: false,
+  linkifyHeadings: false,
+  syntaxHighlight: false,
+  markedOptions: {}
+};
+
 module.exports = function compileMarkdown(source, config) {
   let tokens = marked.lexer(source);
 
   // we need to use marked.defaults to preserve marked default options
   let markedOptions = Object.assign(marked.defaults, config.markedOptions);
+  config = Object.assign(DEFAULTS, config);
 
   markedOptions.renderer = new HBSRenderer(config);
 

--- a/lib/markdown-template-compiler.js
+++ b/lib/markdown-template-compiler.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const stew = require('broccoli-stew');
+const compileMarkdown = require('./compile-markdown');
+
+module.exports = class MarkdownTemplateCompiler {
+  constructor(options) {
+    this.name = 'markdown-template-compiler';
+    this.ext = ['md', 'markdown'];
+    this.options = options || {};
+  }
+
+  toTree(tree) {
+    let compiled = stew.map(tree, `**/*.{${this.ext}}`, string => compileMarkdown(string, this.options));
+
+    return stew.rename(compiled, '.md', '.hbs');
+  }
+};

--- a/package.json
+++ b/package.json
@@ -21,12 +21,14 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "broccoli-filter": "^1.2.2",
+    "broccoli-stew": "^2.0.0",
     "ember-cli-babel": "^6.6.0",
-    "showdown": "^1.6.4"
+    "highlightjs": "^9.10.0",
+    "marked": "^0.5.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.7.0",
+    "broccoli-stew": "^2.0.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~3.2.0",
     "ember-cli-dependency-checker": "^2.0.0",

--- a/tests/acceptance/application-render-test.js
+++ b/tests/acceptance/application-render-test.js
@@ -10,7 +10,7 @@ module('Acceptance: Application Render Test', function(hooks) {
 
     await visit('/');
 
-    assert.dom('h1#hello').hasText("Hello!");
-    assert.equal(this.element.querySelector('h1#hello ~ p').innerHTML, "This is <code>ember-cli-markdown-templates</code>.");
+    assert.dom('h1#header-hello-').hasText('Hello!');
+    assert.equal(this.element.querySelector('h1#header-hello- ~ p').innerHTML, "This is <code>ember-cli-markdown-templates</code>.");
   });
 });

--- a/tests/dummy/app/templates/application.md
+++ b/tests/dummy/app/templates/application.md
@@ -1,2 +1,7 @@
 # Hello!
 This is `ember-cli-markdown-templates`.
+
+
+```js
+let a = 'a string';
+```

--- a/yarn.lock
+++ b/yarn.lock
@@ -1099,7 +1099,7 @@ broccoli-lint-eslint@^4.2.1:
     lodash.defaultsdeep "^4.6.0"
     md5-hex "^2.0.0"
 
-broccoli-merge-trees@^1.0.0:
+broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz#a001519bb5067f06589d91afa2942445a2d0fdb5"
   dependencies:
@@ -1118,6 +1118,13 @@ broccoli-merge-trees@^2.0.0:
   dependencies:
     broccoli-plugin "^1.3.0"
     merge-trees "^1.0.1"
+
+broccoli-merge-trees@^3.0.0, broccoli-merge-trees@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-3.0.1.tgz#545dfe9f695cec43372b3ee7e63c7203713ea554"
+  dependencies:
+    broccoli-plugin "^1.3.0"
+    merge-trees "^2.0.0"
 
 broccoli-middleware@^1.2.1:
   version "1.2.1"
@@ -1220,6 +1227,25 @@ broccoli-stew@^1.2.0, broccoli-stew@^1.5.0:
     resolve "^1.1.6"
     rsvp "^3.0.16"
     symlink-or-copy "^1.1.8"
+    walk-sync "^0.3.0"
+
+broccoli-stew@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-2.0.0.tgz#68f3d94f13b4a79aa15d582703574fb4c3215e50"
+  dependencies:
+    broccoli-debug "^0.6.1"
+    broccoli-funnel "^2.0.0"
+    broccoli-merge-trees "^3.0.0"
+    broccoli-persistent-filter "^1.1.6"
+    broccoli-plugin "^1.3.0"
+    chalk "^2.4.1"
+    debug "^3.1.0"
+    ensure-posix-path "^1.0.1"
+    fs-extra "^6.0.1"
+    minimatch "^3.0.4"
+    resolve "^1.8.1"
+    rsvp "^4.8.3"
+    symlink-or-copy "^1.2.0"
     walk-sync "^0.3.0"
 
 broccoli-uglify-sourcemap@^2.1.1:
@@ -1332,10 +1358,6 @@ camelcase@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
-camelcase@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
-
 can-symlink@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/can-symlink/-/can-symlink-1.0.0.tgz#97b607d8a84bb6c6e228b902d864ecb594b9d219"
@@ -1376,7 +1398,7 @@ chalk@^1.0.0, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -1449,6 +1471,10 @@ clean-css@^3.4.5:
     commander "2.8.x"
     source-map "0.4.x"
 
+clean-up-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clean-up-path/-/clean-up-path-1.0.0.tgz#de9e8196519912e749c9eaf67c13d64fac72a3e5"
+
 cli-cursor@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
@@ -1491,14 +1517,6 @@ cliui@^2.1.0:
     center-align "^0.1.1"
     right-align "^0.1.1"
     wordwrap "0.0.2"
-
-cliui@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
-  dependencies:
-    string-width "^2.1.1"
-    strip-ansi "^4.0.0"
-    wrap-ansi "^2.0.0"
 
 clone-response@1.0.2:
   version "1.0.2"
@@ -1690,7 +1708,7 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cross-spawn@^5.0.1, cross-spawn@^5.1.0:
+cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
@@ -1734,7 +1752,7 @@ debug@^3.1.0, debug@~3.1.0:
   dependencies:
     ms "2.0.0"
 
-decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
+decamelize@^1.0.0, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
@@ -1950,6 +1968,17 @@ ember-cli-lodash-subset@^1.0.7:
 ember-cli-lodash-subset@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-2.0.1.tgz#20cb68a790fe0fde2488ddfd8efbb7df6fe766f2"
+
+ember-cli-node-assets@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-node-assets/-/ember-cli-node-assets-0.2.2.tgz#d2d55626e7cc6619f882d7fe55751f9266022708"
+  dependencies:
+    broccoli-funnel "^1.0.1"
+    broccoli-merge-trees "^1.1.1"
+    broccoli-source "^1.1.0"
+    debug "^2.2.0"
+    lodash "^4.5.1"
+    resolve "^1.1.7"
 
 ember-cli-normalize-entity-name@^1.0.0:
   version "1.0.0"
@@ -2451,18 +2480,6 @@ execa@^0.10.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execa@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
-  dependencies:
-    cross-spawn "^5.0.1"
-    get-stream "^3.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
-
 exists-stat@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/exists-stat/-/exists-stat-1.0.0.tgz#0660e3525a2e89d9e446129440c272edfa24b529"
@@ -2826,6 +2843,14 @@ fs-extra@^5.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
@@ -2840,6 +2865,16 @@ fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5
     object-assign "^4.1.0"
     path-posix "^1.0.0"
     symlink-or-copy "^1.1.8"
+
+fs-updater@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/fs-updater/-/fs-updater-1.0.4.tgz#2329980f99ae9176e9a0e84f7637538a182ce63b"
+  dependencies:
+    can-symlink "^1.0.0"
+    clean-up-path "^1.0.0"
+    heimdalljs "^0.2.5"
+    heimdalljs-logger "^0.1.9"
+    rimraf "^2.6.2"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2869,7 +2904,7 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-get-caller-file@^1.0.0, get-caller-file@^1.0.1:
+get-caller-file@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
 
@@ -3098,6 +3133,16 @@ heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3:
   dependencies:
     rsvp "~3.2.1"
 
+heimdalljs@^0.2.5:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.2.6.tgz#b0eebabc412813aeb9542f9cc622cb58dbdcd9fe"
+  dependencies:
+    rsvp "~3.2.1"
+
+highlightjs@^9.10.0:
+  version "9.10.0"
+  resolved "https://registry.yarnpkg.com/highlightjs/-/highlightjs-9.10.0.tgz#fca9b78ddaa3b1abca89d6c3ee105ad270a80190"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -3262,10 +3307,6 @@ invariant@^2.2.2:
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
     loose-envify "^1.0.0"
-
-invert-kv@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
 ipaddr.js@1.6.0:
   version "1.6.0"
@@ -3637,12 +3678,6 @@ lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
 
-lcid@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
-  dependencies:
-    invert-kv "^1.0.0"
-
 leek@0.0.24:
   version "0.0.24"
   resolved "https://registry.yarnpkg.com/leek/-/leek-0.0.24.tgz#e400e57f0e60d8ef2bd4d068dc428a54345dbcda"
@@ -4012,7 +4047,7 @@ lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.17.10, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.6.1:
+lodash@^4.17.10, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -4104,6 +4139,10 @@ markdown-it@^8.3.0, markdown-it@^8.3.1:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
+marked@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.5.0.tgz#9e590bad31584a48ff405b33ab1c0dd25172288e"
+
 matcher-collection@^1.0.0, matcher-collection@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/matcher-collection/-/matcher-collection-1.0.5.tgz#2ee095438372cb8884f058234138c05c644ec339"
@@ -4131,12 +4170,6 @@ mdurl@^1.0.1:
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
-
-mem@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
-  dependencies:
-    mimic-fn "^1.0.0"
 
 memory-streams@^0.1.3:
   version "0.1.3"
@@ -4173,6 +4206,13 @@ merge-trees@^1.0.1:
     heimdalljs-logger "^0.1.7"
     rimraf "^2.4.3"
     symlink-or-copy "^1.0.0"
+
+merge-trees@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-trees/-/merge-trees-2.0.0.tgz#a560d796e566c5d9b2c40472a2967cca48d85161"
+  dependencies:
+    fs-updater "^1.0.4"
+    heimdalljs "^0.2.5"
 
 merge@^1.2.0:
   version "1.2.0"
@@ -4575,14 +4615,6 @@ ora@^2.0.0:
 os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
-
-os-locale@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
-  dependencies:
-    execa "^0.7.0"
-    lcid "^1.0.0"
-    mem "^1.1.0"
 
 os-shim@^0.1.2:
   version "0.1.3"
@@ -5029,14 +5061,6 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-require-directory@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
-
-require-main-filename@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
-
 require-uncached@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
@@ -5069,7 +5093,7 @@ resolve@1.5.0:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.1.6, resolve@^1.3.0, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.0, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
@@ -5119,7 +5143,7 @@ rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
 
-rsvp@^4.6.1, rsvp@^4.7.0, rsvp@^4.8.2:
+rsvp@^4.6.1, rsvp@^4.7.0, rsvp@^4.8.2, rsvp@^4.8.3:
   version "4.8.3"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.3.tgz#25d4b9fdd0f95e216eb5884d9b3767d3fbfbe2cd"
 
@@ -5219,7 +5243,7 @@ serve-static@1.13.2:
     parseurl "~1.3.2"
     send "0.16.2"
 
-set-blocking@^2.0.0, set-blocking@~2.0.0:
+set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
 
@@ -5266,12 +5290,6 @@ shebang-regex@^1.0.0:
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
-
-showdown@^1.6.4:
-  version "1.8.6"
-  resolved "https://registry.yarnpkg.com/showdown/-/showdown-1.8.6.tgz#91ea4ee3b7a5448aaca6820a4e27e690c6ad771c"
-  dependencies:
-    yargs "^10.0.3"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
@@ -5981,10 +5999,6 @@ websocket-extensions@>=0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
 
-which-module@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
-
 which@^1.2.14, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -6018,13 +6032,6 @@ workerpool@^2.3.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-2.3.0.tgz#86c5cbe946b55e7dc9d12b1936c8801a6e2d744d"
   dependencies:
     object-assign "4.1.1"
-
-wrap-ansi@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
-  dependencies:
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
 
 wrappy@1:
   version "1.0.2"
@@ -6068,10 +6075,6 @@ xtend@^4.0.0, xtend@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
-y18n@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
-
 yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
@@ -6086,29 +6089,6 @@ yam@^0.0.24:
   dependencies:
     fs-extra "^4.0.2"
     lodash.merge "^4.6.0"
-
-yargs-parser@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
-  dependencies:
-    camelcase "^4.1.0"
-
-yargs@^10.0.3:
-  version "10.1.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.1.2.tgz#454d074c2b16a51a43e2fb7807e4f9de69ccb5c5"
-  dependencies:
-    cliui "^4.0.0"
-    decamelize "^1.1.1"
-    find-up "^2.1.0"
-    get-caller-file "^1.0.1"
-    os-locale "^2.0.0"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^8.1.0"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
Greetings!

I've been following closely the work being done at [ember-cli-addon-docs](https://github.com/ember-learn/ember-cli-addon-docs).
They have a very interesting approach for markdown templates.
This PR brings the approach from there, but allows the user to turn on or off all features.

Relevant changes from the current version:
- optionally add syntax highlighting using highlight.js
- optionally add wrapper arbitrary html (closes #1)
- optionally linkify headers e.g render heading as `<h1 id="hello-"><a href="#hello-">Hello!</a></h1>`
- user can completely customize the underlying marked parser with [any supported marked options](https://marked.js.org/#/USING_ADVANCED.md#options)
- please read the updated README for more detail

This this change uses Marked instead of Showdown so it's probably safer to bump the major version, just in case.

That is, if you decide to merge, of course. :)
I think this has a lot of value for users, so this will be released as a separate addon if not merged. But it would be very nice to unify efforts!

Let me know if you need something for me.