### PR TITLE
Fix compactParagraphs for angle-brackets

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,18 +4,12 @@ module.exports = {
     ecmaVersion: 2017,
     sourceType: 'module'
   },
-  plugins: [
-    'ember'
-  ],
-  extends: [
-    'eslint:recommended',
-    'plugin:ember/recommended'
-  ],
+  plugins: ['ember'],
+  extends: ['eslint:recommended', 'plugin:ember/recommended'],
   env: {
     browser: true
   },
-  rules: {
-  },
+  rules: {},
   overrides: [
     // node files
     {
@@ -27,6 +21,7 @@ module.exports = {
         'config/**/*.js',
         'lib/**/*.js',
         'tests/dummy/config/**/*.js',
+        'tests-node/**/*.js'
       ],
       excludedFiles: [
         'addon/**',
@@ -43,9 +38,13 @@ module.exports = {
         node: true
       },
       plugins: ['node'],
-      rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
-        // add your custom rules and overrides for node files here
-      })
+      rules: Object.assign(
+        {},
+        require('eslint-plugin-node').configs.recommended.rules,
+        {
+          // add your custom rules and overrides for node files here
+        }
+      )
     }
   ]
 };

--- a/lib/compile-markdown.js
+++ b/lib/compile-markdown.js
@@ -87,16 +87,16 @@ function compactParagraphs(tokens) {
     // curly components
     balance += count(/{{#/g, textWithoutCode);
     // angle-bracket components
-    balance += count(/<[A-Z][a-zA-Z0-9]*[^<>]+[^/>]>$/gm, textWithoutCode);
+    balance += count(/<[A-Z][a-zA-Z0-9]*[^<>]+[^/>]>/g, textWithoutCode);
     // yielded angle-bracket components (containing a dot)
-    balance += count(/<[a-zA-Z]+\.[a-zA-Z]+[^<>]+[^/>]>$/gm, textWithoutCode);
+    balance += count(/<[a-zA-Z]+\.[a-zA-Z]+[^<>]+[^/>]>/g, textWithoutCode);
 
     // curly components
     balance -= count(/{{\//g, textWithoutCode);
     // angle-bracket components
-    balance -= count(/<\/[A-Z][a-zA-Z0-9]*[^<>]+[^/>]>$/gm, textWithoutCode);
+    balance -= count(/<\/[A-Z][a-zA-Z0-9]*[^<>]+[^/>]>/g, textWithoutCode);
     // yielded angle-bracket components (containing a dot)
-    balance -= count(/<\/[a-zA-Z]+\.[a-zA-Z]+[^<>]+[^/>]>$/gm, textWithoutCode);
+    balance -= count(/<\/[a-zA-Z]+\.[a-zA-Z]+[^<>]+[^/>]>/g, textWithoutCode);
   }
 
   return compacted;

--- a/lib/compile-markdown.js
+++ b/lib/compile-markdown.js
@@ -12,7 +12,14 @@ const DEFAULTS = {
 };
 
 module.exports = function compileMarkdown(source, config) {
-  let tokens = marked.lexer(source);
+  const lexer = new marked.Lexer();
+  let rules = lexer.rules.html.source || lexer.rules.html;
+  rules = rules.replace(
+    '|<![A-Z][\\s\\S]*?>\\n*',
+    '|</?([A-Z][a-zA-Z.]+)(?: +|\\n|/?>)[\\s\\S]*?(?:\\n{2,}|$)'
+  );
+  lexer.rules.html = new RegExp(rules, 'i');
+  let tokens = lexer.lex(source);
 
   // we need to use marked.defaults to preserve marked default options
   let markedOptions = Object.assign(marked.defaults, config.markedOptions);
@@ -77,11 +84,19 @@ function compactParagraphs(tokens) {
     let tokenText = token.text || '';
     let textWithoutCode = tokenText.replace(/`[\s\S]*?`/g, '');
 
+    // curly components
     balance += count(/{{#/g, textWithoutCode);
-    balance += count(/<[A-Z]/g, textWithoutCode);
-    balance -= count(/[A-Z][^<>]+\/>/g, textWithoutCode);
+    // angle-bracket components
+    balance += count(/<[A-Z][a-zA-Z0-9]*[^<>]+[^/>]>$/gm, textWithoutCode);
+    // yielded angle-bracket components (containing a dot)
+    balance += count(/<[a-zA-Z]+\.[a-zA-Z]+[^<>]+[^/>]>$/gm, textWithoutCode);
+
+    // curly components
     balance -= count(/{{\//g, textWithoutCode);
-    balance -= count(/<\/[A-Z]/g, textWithoutCode);
+    // angle-bracket components
+    balance -= count(/<\/[A-Z][a-zA-Z0-9]*[^<>]+[^/>]>$/gm, textWithoutCode);
+    // yielded angle-bracket components (containing a dot)
+    balance -= count(/<\/[a-zA-Z]+\.[a-zA-Z]+[^<>]+[^/>]>$/gm, textWithoutCode);
   }
 
   return compacted;
@@ -121,6 +136,14 @@ class HBSRenderer extends marked.Renderer {
     }
     return text;
   }
+
+  // paragraph(text) {
+  //   console.log('PARAGRAPH', text);
+  // }
+
+  // link(href, title, text) {
+  //   console.log('LINK', href, title, text);
+  // }
 
   // Escape curlies in code spans/blocks to avoid treating them as Handlebars
   _processCode(string) {

--- a/lib/compile-markdown.js
+++ b/lib/compile-markdown.js
@@ -2,6 +2,7 @@
 
 const marked = require('marked');
 const highlightjs = require('highlightjs');
+const fm = require('front-matter');
 
 const DEFAULTS = {
   targetHandlebars: true,
@@ -12,6 +13,8 @@ const DEFAULTS = {
 };
 
 module.exports = function compileMarkdown(source, config) {
+  const content = fm(source);
+
   const lexer = new marked.Lexer();
   let rules = lexer.rules.html.source || lexer.rules.html;
   rules = rules.replace(
@@ -19,7 +22,7 @@ module.exports = function compileMarkdown(source, config) {
     '|</?([A-Z][a-zA-Z.]+)(?: +|\\n|/?>)[\\s\\S]*?(?:\\n{2,}|$)'
   );
   lexer.rules.html = new RegExp(rules, 'i');
-  let tokens = lexer.lex(source);
+  let tokens = lexer.lex(content.body);
 
   // we need to use marked.defaults to preserve marked default options
   let markedOptions = Object.assign(marked.defaults, config.markedOptions);
@@ -47,6 +50,12 @@ module.exports = function compileMarkdown(source, config) {
       );
     }
     html = config.wrapper.replace('{{html}}', html);
+  }
+
+  content.html = html;
+
+  if (config.format) {
+    html = config.format(content);
   }
 
   return html;

--- a/lib/compile-markdown.js
+++ b/lib/compile-markdown.js
@@ -31,8 +31,13 @@ module.exports = function compileMarkdown(source, config) {
   let html = marked.parser(tokens, markedOptions).trim();
 
   if (config.wrapper) {
-    if (typeof config.wrapper !== 'string' || config.wrapper.indexOf('{{html}}') === -1) {
-      throw new Error('ember-cli-markdown-templates the passed in `wrapper` config is either not a string or does not have a {{html}} substring');
+    if (
+      typeof config.wrapper !== 'string' ||
+      config.wrapper.indexOf('{{html}}') === -1
+    ) {
+      throw new Error(
+        'ember-cli-markdown-templates the passed in `wrapper` config is either not a string or does not have a {{html}} substring'
+      );
     }
     html = config.wrapper.replace('{{html}}', html);
   }
@@ -69,8 +74,14 @@ function compactParagraphs(tokens) {
       last.text = `${last.text} ${token.text}`;
     }
 
-    balance += count(/\{\{#/g, token.text);
-    balance -= count(/\{\{\//g, token.text);
+    let tokenText = token.text || '';
+    let textWithoutCode = tokenText.replace(/`[\s\S]*?`/g, '');
+
+    balance += count(/{{#/g, textWithoutCode);
+    balance += count(/<[A-Z]/g, textWithoutCode);
+    balance -= count(/[A-Z][^<>]+\/>/g, textWithoutCode);
+    balance -= count(/{{\//g, textWithoutCode);
+    balance -= count(/<\/[A-Z]/g, textWithoutCode);
   }
 
   return compacted;
@@ -106,7 +117,7 @@ class HBSRenderer extends marked.Renderer {
         .replace(/&lt;/g, '<')
         .replace(/&gt;/g, '>')
         .replace(/&quot;|&#34;/g, '"')
-        .replace(/&apos;|&#39;/g, '\'');
+        .replace(/&apos;|&#39;/g, "'");
     }
     return text;
   }
@@ -121,18 +132,22 @@ class HBSRenderer extends marked.Renderer {
   }
 
   _escapeCurlies(string) {
-    return string
-      .replace(/{{/g, '&#123;&#123;')
-      .replace(/}}/g, '&#125;&#125;');
+    return string.replace(/{{/g, '&#123;&#123;').replace(/}}/g, '&#125;&#125;');
   }
 
   heading(text, level) {
     let linkifyHeadings = this.config.linkifyHeadings;
 
     if (linkifyHeadings) {
-      let sinceLevel = typeof linkifyHeadings === 'boolean' ? 1 : this.config.linkifyHeadings;
+      let sinceLevel =
+        typeof linkifyHeadings === 'boolean' ? 1 : this.config.linkifyHeadings;
 
-      let id = this.options.headerPrefix + text.toLowerCase().replace(/<\/?.*?>/g, '').replace(/[^\w]+/g, '-');
+      let id =
+        this.options.headerPrefix +
+        text
+          .toLowerCase()
+          .replace(/<\/?.*?>/g, '')
+          .replace(/[^\w]+/g, '-');
       let inner = level < sinceLevel ? text : `<a href="#${id}">${text}</a>`;
 
       return `

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint:js": "eslint .",
     "start": "ember serve",
     "test": "ember test",
+    "test-node": "qunit tests-node/unit/**/*-test.js",
     "test:all": "ember try:each"
   },
   "dependencies": {
@@ -51,7 +52,8 @@
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^6.0.1",
     "loader.js": "^4.2.3",
-    "qunit-dom": "^0.6.2"
+    "qunit-dom": "^0.6.2",
+    "qunitjs": "^2.4.1"
   },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "broccoli-stew": "^2.0.0",
     "ember-cli-babel": "^6.6.0",
+    "front-matter": "^3.0.2",
     "highlightjs": "^9.10.0",
     "marked": "^0.5.0"
   },

--- a/tests-node/unit/compile-test.js
+++ b/tests-node/unit/compile-test.js
@@ -33,16 +33,68 @@ test('should compact code with yield', function(assert) {
 
   const html = `<h3 id="sample-h3">Sample h3</h3>
 <p>  Some text</p>
-<p>  <CodeSnippet @name="foo/bar.txt"/></p>
+  <CodeSnippet @name="foo/bar.txt"/>
+
 <p>  Second paragraph:</p>
-<p>  <Tabs as |tabs|>
+  <Tabs as |tabs|>
     <tabs.Page @title="template.hbs">
       <CodeSnippet @name="template.hbs" />
-    </tabs.Page> <tabs.Page @title="component.ts">
+    </tabs.Page>
+
+ <tabs.Page @title="component.ts">
   <CodeSnippet @name="component.ts" />
 </tabs.Page>   </Tabs>
 
-</p>
+<h3 id="another-h3">Another h3</h3>`;
+
+  assert.equal(compiled, html);
+});
+
+test('should compact code with yield and inline html in paragraph', function(assert) {
+  const code = `
+  ### Sample h3
+
+  Some text
+
+  <CodeSnippet @name="foo/bar.txt"/>
+
+  Second <i>para</i>graph with a little more
+  text and a line break. Additionally, there is also
+  a <LinkTo @route="to.the.house">link</LinkTo> embedded
+  into it.
+
+  <References class="references" as |l|>
+    <l.BlogPost
+      @title="Ember 2019: Reduce Complexity"
+      @year="2019"
+      @url="https://gos.si/blog/ember-2019-reduce-complexity"
+    as |r|>
+      <r.Author @given="Thomas" @family="Gossmann"/>
+    </l.BlogPost>
+  </References>
+
+  ### Another h3
+  `;
+  const compiled = compileMarkdown(code, {});
+
+  const html = `<h3 id="sample-h3">Sample h3</h3>
+<p>  Some text</p>
+  <CodeSnippet @name="foo/bar.txt"/>
+
+<p>  Second <i>para</i>graph with a little more
+  text and a line break. Additionally, there is also
+  a <LinkTo @route="to.the.house">link</LinkTo> embedded
+  into it.</p>
+  <References class="references" as |l|>
+    <l.BlogPost
+      @title="Ember 2019: Reduce Complexity"
+      @year="2019"
+      @url="https://gos.si/blog/ember-2019-reduce-complexity"
+    as |r|>
+      <r.Author @given="Thomas" @family="Gossmann"/>
+    </l.BlogPost>
+  </References>
+
 <h3 id="another-h3">Another h3</h3>`;
 
   assert.equal(compiled, html);
@@ -69,7 +121,8 @@ test('should compact paragraphs without yield', function(assert) {
 
   const html = `<h3 id="sample-h3">Sample h3</h3>
 <p>  Some text</p>
-<p>  <CodeSnippet @name="foo/bar.txt"/></p>
+  <CodeSnippet @name="foo/bar.txt"/>
+
 <p>  Second paragraph:</p>
   <Tabs>
     Tab content

--- a/tests-node/unit/compile-test.js
+++ b/tests-node/unit/compile-test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const QUnit = require('qunitjs'),
+  test = QUnit.test,
+  testModule = QUnit.module;
+const compileMarkdown = require('../../lib/compile-markdown');
+
+testModule('Unit | Markdown Compiler');
+
+test('should compact code with yield', function(assert) {
+  const code = `
+  ### Sample h3
+
+  Some text
+
+  <CodeSnippet @name="foo/bar.txt"/>
+
+  Second paragraph:
+
+  <Tabs as |tabs|>
+    <tabs.Page @title="template.hbs">
+      <CodeSnippet @name="template.hbs" />
+    </tabs.Page>
+
+    <tabs.Page @title="component.ts">
+      <CodeSnippet @name="component.ts" />
+    </tabs.Page>
+  </Tabs>
+
+  ### Another h3
+  `;
+  const compiled = compileMarkdown(code, {});
+
+  const html = `<h3 id="sample-h3">Sample h3</h3>
+<p>  Some text</p>
+<p>  <CodeSnippet @name="foo/bar.txt"/></p>
+<p>  Second paragraph:</p>
+<p>  <Tabs as |tabs|>
+    <tabs.Page @title="template.hbs">
+      <CodeSnippet @name="template.hbs" />
+    </tabs.Page> <tabs.Page @title="component.ts">
+  <CodeSnippet @name="component.ts" />
+</tabs.Page>   </Tabs>
+
+</p>
+<h3 id="another-h3">Another h3</h3>`;
+
+  assert.equal(compiled, html);
+});
+
+test('should compact paragraphs without yield', function(assert) {
+  const code = `
+  ### Sample h3
+
+  Some text
+
+  <CodeSnippet @name="foo/bar.txt"/>
+
+  Second paragraph:
+
+  <Tabs>
+    Tab content
+  </Tabs>
+
+  ### Another h3
+  `;
+
+  const compiled = compileMarkdown(code, {});
+
+  const html = `<h3 id="sample-h3">Sample h3</h3>
+<p>  Some text</p>
+<p>  <CodeSnippet @name="foo/bar.txt"/></p>
+<p>  Second paragraph:</p>
+  <Tabs>
+    Tab content
+  </Tabs>
+
+<h3 id="another-h3">Another h3</h3>`;
+
+  assert.equal(compiled, html);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1099,7 +1099,7 @@ broccoli-lint-eslint@^4.2.1:
     lodash.defaultsdeep "^4.6.0"
     md5-hex "^2.0.0"
 
-broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.1:
+broccoli-merge-trees@^1.0.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz#a001519bb5067f06589d91afa2942445a2d0fdb5"
   dependencies:
@@ -1119,7 +1119,7 @@ broccoli-merge-trees@^2.0.0:
     broccoli-plugin "^1.3.0"
     merge-trees "^1.0.1"
 
-broccoli-merge-trees@^3.0.0, broccoli-merge-trees@^3.0.1:
+broccoli-merge-trees@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-3.0.1.tgz#545dfe9f695cec43372b3ee7e63c7203713ea554"
   dependencies:
@@ -1416,6 +1416,22 @@ charm@^1.0.0:
   dependencies:
     inherits "^2.0.1"
 
+chokidar@1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.6.1.tgz#2f4447ab5e96e50fb3d789fd90d4c72e0e4c70c2"
+  integrity sha1-L0RHq16W5Q+z14n9kNTHLg5McMI=
+  dependencies:
+    anymatch "^1.3.0"
+    async-each "^1.0.0"
+    glob-parent "^2.0.0"
+    inherits "^2.0.1"
+    is-binary-path "^1.0.0"
+    is-glob "^2.0.0"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.0.0"
+  optionalDependencies:
+    fsevents "^1.0.0"
+
 chokidar@1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -1572,6 +1588,13 @@ commander@2.12.2:
 commander@2.8.x:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
+  dependencies:
+    graceful-readlink ">= 1.0.0"
+
+commander@2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
   dependencies:
     graceful-readlink ">= 1.0.0"
 
@@ -1827,6 +1850,13 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
 
+detect-file@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-0.1.0.tgz#4935dedfd9488648e006b0129566e9386711ea63"
+  integrity sha1-STXe39lIhkjgBrASlWbpOGcR6mM=
+  dependencies:
+    fs-exists-sync "^0.1.0"
+
 detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
@@ -1968,17 +1998,6 @@ ember-cli-lodash-subset@^1.0.7:
 ember-cli-lodash-subset@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-2.0.1.tgz#20cb68a790fe0fde2488ddfd8efbb7df6fe766f2"
-
-ember-cli-node-assets@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/ember-cli-node-assets/-/ember-cli-node-assets-0.2.2.tgz#d2d55626e7cc6619f882d7fe55751f9266022708"
-  dependencies:
-    broccoli-funnel "^1.0.1"
-    broccoli-merge-trees "^1.1.1"
-    broccoli-source "^1.1.0"
-    debug "^2.2.0"
-    lodash "^4.5.1"
-    resolve "^1.1.7"
 
 ember-cli-normalize-entity-name@^1.0.0:
   version "1.0.0"
@@ -2524,6 +2543,13 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
+expand-tilde@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-1.2.2.tgz#0b81eba897e5a3d31d1c3d102f8f01441e559449"
+  integrity sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=
+  dependencies:
+    os-homedir "^1.0.1"
+
 expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
@@ -2736,6 +2762,16 @@ find-yarn-workspace-root@^1.0.0, find-yarn-workspace-root@^1.1.0:
     fs-extra "^4.0.3"
     micromatch "^3.1.4"
 
+findup-sync@0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-0.4.3.tgz#40043929e7bc60adf0b7f4827c4c6e75a0deca12"
+  integrity sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=
+  dependencies:
+    detect-file "^0.1.0"
+    is-glob "^2.0.1"
+    micromatch "^2.3.7"
+    resolve-dir "^0.1.0"
+
 findup-sync@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-2.0.0.tgz#9326b1488c22d1a6088650a86901b2d9a90a2cbc"
@@ -2800,6 +2836,11 @@ from2@^2.1.1:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
+
+fs-exists-sync@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
+  integrity sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=
 
 fs-extra@^0.24.0:
   version "0.24.0"
@@ -2958,6 +2999,14 @@ glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+global-modules@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-0.2.3.tgz#ea5a3bed42c6d6ce995a4f8a1269b5dae223828d"
+  integrity sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=
+  dependencies:
+    global-prefix "^0.1.4"
+    is-windows "^0.2.0"
+
 global-modules@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
@@ -2965,6 +3014,16 @@ global-modules@^1.0.0:
     global-prefix "^1.0.1"
     is-windows "^1.0.1"
     resolve-dir "^1.0.0"
+
+global-prefix@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-0.1.5.tgz#8d3bc6b8da3ca8112a160d8d496ff0462bfef78f"
+  integrity sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=
+  dependencies:
+    homedir-polyfill "^1.0.0"
+    ini "^1.3.4"
+    is-windows "^0.2.0"
+    which "^1.2.12"
 
 global-prefix@^1.0.1:
   version "1.0.2"
@@ -3149,6 +3208,13 @@ home-or-tmp@^2.0.0:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
+
+homedir-polyfill@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz#743298cef4e5af3e194161fbadcc2151d3a058e8"
+  integrity sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
+  dependencies:
+    parse-passwd "^1.0.0"
 
 homedir-polyfill@^1.0.1:
   version "1.0.1"
@@ -3516,6 +3582,11 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+is-windows@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
+  integrity sha1-3hqm1j6indJIc3tp8f+LgALSEIw=
+
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
@@ -3568,6 +3639,11 @@ isurl@^1.0.0-alpha5:
 jquery@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
+
+js-reporters@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/js-reporters/-/js-reporters-1.2.0.tgz#7cf2cb698196684790350d0c4ca07f4aed9ec17e"
+  integrity sha1-fPLLaYGWaEeQNQ0MTKB/Su2ewX4=
 
 js-reporters@1.2.1:
   version "1.2.1"
@@ -4047,7 +4123,7 @@ lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.17.10, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1:
+lodash@^4.17.10, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -4222,7 +4298,7 @@ methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
-micromatch@^2.1.5:
+micromatch@^2.1.5, micromatch@^2.3.7:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
   dependencies:
@@ -4880,6 +4956,19 @@ qunit@^2.5.0:
     resolve "1.5.0"
     walk-sync "0.3.2"
 
+qunitjs@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/qunitjs/-/qunitjs-2.4.1.tgz#88aba055a9e2ec3dbebfaad02471b2cb002c530b"
+  integrity sha512-by/2zYvsNdS6Q6Ev6UJ3qJK+OYVlTzWlQ4afaeYMhVh1dd2K3N1ZZKCrCm3WSWPnz5ELMT8WyJRcVy5PXT2y+Q==
+  dependencies:
+    chokidar "1.6.1"
+    commander "2.9.0"
+    exists-stat "1.0.0"
+    findup-sync "0.4.3"
+    js-reporters "1.2.0"
+    resolve "1.3.2"
+    walk-sync "0.3.1"
+
 randomatic@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-3.0.0.tgz#d35490030eb4f7578de292ce6dfb04a91a128923"
@@ -5072,6 +5161,14 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
+resolve-dir@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-0.1.1.tgz#b219259a5602fac5c5c496ad894a6e8cc430261e"
+  integrity sha1-shklmlYC+sXFxJatiUpujMQwJh4=
+  dependencies:
+    expand-tilde "^1.2.2"
+    global-modules "^0.2.3"
+
 resolve-dir@^1.0.0, resolve-dir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
@@ -5087,13 +5184,20 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
+resolve@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.2.tgz#1f0442c9e0cbb8136e87b9305f932f46c7f28235"
+  integrity sha1-HwRCyeDLuBNuh7kwX5MvRsfygjU=
+  dependencies:
+    path-parse "^1.0.5"
+
 resolve@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.3.0, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1:
+resolve@^1.1.6, resolve@^1.3.0, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
@@ -5945,6 +6049,14 @@ vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
 
+walk-sync@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.3.1.tgz#558a16aeac8c0db59c028b73c66f397684ece465"
+  integrity sha1-VYoWrqyMDbWcAotzxm85doTs5GU=
+  dependencies:
+    ensure-posix-path "^1.0.0"
+    matcher-collection "^1.0.0"
+
 walk-sync@0.3.2, walk-sync@^0.3.0, walk-sync@^0.3.1, walk-sync@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.3.2.tgz#4827280afc42d0e035367c4a4e31eeac0d136f75"
@@ -5999,7 +6111,7 @@ websocket-extensions@>=0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
 
-which@^1.2.14, which@^1.2.9, which@^1.3.0:
+which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2837,6 +2837,13 @@ from2@^2.1.1:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
+front-matter@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/front-matter/-/front-matter-3.0.2.tgz#2401cd05fcf22bd0de48a104ffb4efb1ff5c8465"
+  integrity sha512-iBGZaWyzqgsrPGsqrXZP6N4hp5FzSKDi18nfAoYpgz3qK5sAwFv/ojmn3VS60SOgLvq6CtojNqy0y6ZNz05IzQ==
+  dependencies:
+    js-yaml "^3.13.1"
+
 fs-exists-sync@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
@@ -3656,6 +3663,14 @@ js-reporters@1.2.1:
 js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+
+js-yaml@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
 
 js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.6.1, js-yaml@^3.9.1:
   version "3.12.0"


### PR DESCRIPTION
I realized, I couldn't have `<Tabs as |tabs|>` in my markdown template (but could have it in ec-addon-docs).

So I backported their adjustments to this package.

Line I copied over: https://github.com/ember-learn/ember-cli-addon-docs/blob/f0a4c6c5532da0eb14fbdb32bdb6e3fe6f4b74ee/addon/utils/compile-markdown.js#L133-L140

I also added two node-tests, to verify it's not breaking. Run them with `yarn test-node` (you may want to adjust CI here).