### PR TITLE
allow custom renderer

### DIFF
--- a/lib/compile-markdown.js
+++ b/lib/compile-markdown.js
@@ -3,6 +3,7 @@
 const marked = require('marked');
 const highlightjs = require('highlightjs');
 const fm = require('front-matter');
+const HBSRenderer = require('./hbs-renderer');
 
 const DEFAULTS = {
   targetHandlebars: true,
@@ -28,7 +29,11 @@ module.exports = function compileMarkdown(source, config) {
   let markedOptions = Object.assign(marked.defaults, config.markedOptions);
   config = Object.assign(DEFAULTS, config);
 
-  markedOptions.renderer = new HBSRenderer(config);
+  // allow user to pass in a custom renderer
+  // otherwise use default one
+  if (!config.markedOptions.renderer) {
+    markedOptions.renderer = new HBSRenderer(config);
+  }
 
   if (config.syntaxHighlight) {
     markedOptions.highlight = highlight;
@@ -117,76 +122,4 @@ function count(regex, string) {
   return total;
 }
 
-class HBSRenderer extends marked.Renderer {
-  constructor(config) {
-    super();
-    this.config = config || {};
-  }
 
-  codespan() {
-    return this._processCode(super.codespan.apply(this, arguments));
-  }
-
-  code() {
-    return this._processCode(super.code.apply(this, arguments));
-  }
-
-  // Unescape markdown escaping in general, since it can interfere with
-  // Handlebars templating
-  text() {
-    let text = super.text.apply(this, arguments);
-    if (this.config.targetHandlebars) {
-      text = text
-        .replace(/&amp;/g, '&')
-        .replace(/&lt;/g, '<')
-        .replace(/&gt;/g, '>')
-        .replace(/&quot;|&#34;/g, '"')
-        .replace(/&apos;|&#39;/g, "'");
-    }
-    return text;
-  }
-
-  // paragraph(text) {
-  //   console.log('PARAGRAPH', text);
-  // }
-
-  // link(href, title, text) {
-  //   console.log('LINK', href, title, text);
-  // }
-
-  // Escape curlies in code spans/blocks to avoid treating them as Handlebars
-  _processCode(string) {
-    if (this.config.targetHandlebars) {
-      string = this._escapeCurlies(string);
-    }
-
-    return string;
-  }
-
-  _escapeCurlies(string) {
-    return string.replace(/{{/g, '&#123;&#123;').replace(/}}/g, '&#125;&#125;');
-  }
-
-  heading(text, level) {
-    let linkifyHeadings = this.config.linkifyHeadings;
-
-    if (linkifyHeadings) {
-      let sinceLevel =
-        typeof linkifyHeadings === 'boolean' ? 1 : this.config.linkifyHeadings;
-
-      let id =
-        this.options.headerPrefix +
-        text
-          .toLowerCase()
-          .replace(/<\/?.*?>/g, '')
-          .replace(/[^\w]+/g, '-');
-      let inner = level < sinceLevel ? text : `<a href="#${id}">${text}</a>`;
-
-      return `
-        <h${level} id="${id}">${inner}</h${level}>
-      `;
-    } else {
-      return super.heading.apply(this, arguments);
-    }
-  }
-}

--- a/lib/hbs-renderer.js
+++ b/lib/hbs-renderer.js
@@ -1,0 +1,75 @@
+const marked = require('marked');
+
+module.exports = class HBSRenderer extends marked.Renderer {
+  constructor(config) {
+    super();
+    this.config = config || {};
+  }
+
+  codespan() {
+    return this._processCode(super.codespan.apply(this, arguments));
+  }
+
+  code() {
+    return this._processCode(super.code.apply(this, arguments));
+  }
+
+  // Unescape markdown escaping in general, since it can interfere with
+  // Handlebars templating
+  text() {
+    let text = super.text.apply(this, arguments);
+    if (this.config.targetHandlebars) {
+      text = text
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;|&#34;/g, '"')
+        .replace(/&apos;|&#39;/g, "'");
+    }
+    return text;
+  }
+
+  // paragraph(text) {
+  //   console.log('PARAGRAPH', text);
+  // }
+
+  // link(href, title, text) {
+  //   console.log('LINK', href, title, text);
+  // }
+
+  // Escape curlies in code spans/blocks to avoid treating them as Handlebars
+  _processCode(string) {
+    if (this.config.targetHandlebars) {
+      string = this._escapeCurlies(string);
+    }
+
+    return string;
+  }
+
+  _escapeCurlies(string) {
+    return string.replace(/{{/g, '&#123;&#123;').replace(/}}/g, '&#125;&#125;');
+  }
+
+  heading(text, level) {
+    let linkifyHeadings = this.config.linkifyHeadings;
+
+    if (linkifyHeadings) {
+      let sinceLevel =
+        typeof linkifyHeadings === 'boolean' ? 1 : this.config.linkifyHeadings;
+
+      let id =
+        this.options.headerPrefix +
+        text
+          .toLowerCase()
+          .replace(/<\/?.*?>/g, '')
+          .replace(/[^\w]+/g, '-');
+      let inner = level < sinceLevel ? text : `<a href="#${id}">${text}</a>`;
+
+      return `
+        <h${level} id="${id}">${inner}</h${level}>
+      `;
+    } else {
+      return super.heading.apply(this, arguments);
+    }
+  }
+}


### PR DESCRIPTION
This change, although simple, unlocks some advanced scenarios for passing in a custom marked renderer.

This allows us to import the default renderer, extend it, and pass it back to ember-cli-markdown-templates.

Just a non-breaking change that increases flexibility, so I don't see any reason not to merge.